### PR TITLE
Adding action to login to AWS ECR

### DIFF
--- a/ecr-login/action.yml
+++ b/ecr-login/action.yml
@@ -1,0 +1,16 @@
+name: 'ECR Login'
+description: 'Login to AWS Elastic Container Registry'
+inputs:
+  account:
+    description: 'AWS Account Id (defaults to Dev-Enterprise)'
+    required: false
+    default: '803669300714'
+  region:
+    description: 'AWS Region'
+    required: false
+    default: 'us-east-1'
+runs:
+  using: "composite"
+  steps:
+    - run: aws ecr get-login-password --region ${{inputs.region}} | docker login --username AWS --password-stdin ${{inputs.account}}.dkr.ecr.${{inputs.region}}.amazonaws.com
+      shell: 'bash'


### PR DESCRIPTION
This action is going to be used to publish docker images for content service helpers. This is for containers which will run in a dev environment, so the AWS account (Dev-Enterprise) and region (us-east-1) are set as defaults.

Note that for production images (unzip worker and scorm engine), the images will need to be published per region in a different AWS account, and this will be handle in AWS Code Build using a cs-tools bundle instead.

See https://aws.amazon.com/blogs/compute/authenticating-amazon-ecr-repositories-for-docker-cli-with-credential-helper/

<img width="790" alt="Screen Shot 2022-05-06 at 1 06 41 PM" src="https://user-images.githubusercontent.com/22655/167179491-eab163c1-1714-469b-a314-9ee4358e4d03.png">

Tested this here: https://github.com/Brightspace/d2l-content-service-lambda-cleanup/runs/6324539547?check_suite_focus=true

...which published to here: https://us-east-1.console.aws.amazon.com/ecr/repositories/private/803669300714/cs-worker-cleanup?region=us-east-1
